### PR TITLE
Vriesk

### DIFF
--- a/scripts/konlet-startup.service
+++ b/scripts/konlet-startup.service
@@ -15,7 +15,7 @@
 [Unit]
 Description=Containers on GCE Setup
 Requires=network-online.target
-After=network-online.target
+After=network-online.target google-startup-scripts.service
 
 [Service]
 ExecStart=/usr/bin/konlet-startup


### PR DESCRIPTION
Make Konlet always start after the GCE startup script.