### PR TITLE
 Update konlet build to use Bazel Go rules 0.7.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bazel-bin
+bazel-gce-containers-startup
+bazel-genfiles
+bazel-out
+bazel-testlogs

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Container startup agent is deployed as a Docker container and is hosted in
 Container Registry:
 [gcr.io/gce-containers/konlet](http://gcr.io/gce-containers/konlet).
 
-To build the agent, use bazel command:
+To build the agent using bazel run these commands from the repository root:
 ```shell
-$ bazel build gce-containers-startup
+$ pushd gce-containers-startup
+$ bazel build :gce-containers-startup
+$ popd
 ```
 
 Export your GCP project name to an environment variable:
@@ -27,15 +29,17 @@ Export your GCP project name to an environment variable:
 $ export MY_PROJECT=your-project-name
 ```
 
-To build a Docker image, build binary to 'docker' directory and invoke:
+To build a Docker image, copy the build binary to the 'docker' directory and
+invoke the docker build command:
 ```shell
-$ docker build docker/Dockerfile -t gcr.io/$MY_PROJECT/gce-containers-startup
+$ cp gce-containers-startup/bazel-bin/gce-containers-startup docker/
+$ docker build docker/ -t gcr.io/$MY_PROJECT/gce-containers-startup
 ```
 
 To push resulting Docker image to Google Container Registry you can use [gcloud
 command](https://cloud.google.com/container-registry/docs/pushing-and-pulling):
 ```shell
-$ gcloud docker push gcr.io/$MY_PROJECT/gce-containers-startup
+$ gcloud docker -- push gcr.io/$MY_PROJECT/gce-containers-startup
 ```
 
 ## Usage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ FROM gcr.io/google_containers/ubuntu-slim:0.6
 MAINTAINER gjaskiewicz@google.com
 
 RUN apt-get update && apt-get install -y iptables
-COPY gce-containers-startup.bin /bin/gce-containers-startup
+COPY gce-containers-startup /bin/gce-containers-startup
 
 CMD ["/bin/gce-containers-startup"]
 

--- a/gce-containers-startup/BUILD
+++ b/gce-containers-startup/BUILD
@@ -23,10 +23,7 @@ load(
     "go_library",
     "go_test",
 )
-load(
-    "@bazel_tools//tools/build_defs/docker:docker.bzl",
-    "docker_build",
-)
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_deb", "pkg_tar")
 
 go_prefix("github.com/konlet")

--- a/gce-containers-startup/WORKSPACE
+++ b/gce-containers-startup/WORKSPACE
@@ -1,10 +1,22 @@
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.4.0",
+    tag = "0.7.0",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
-load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_build")
+git_repository(
+    name = "io_bazel_rules_docker",
+    remote = "https://github.com/bazelbuild/rules_docker.git",
+    tag = "v0.3.0",
+)
 
-go_repositories()
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_rules_dependencies",
+    "go_register_toolchains",
+)
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+
+go_rules_dependencies()
+
+go_register_toolchains()


### PR DESCRIPTION
With these changes and updated build instructions I can successfully build the gce-containers-startup binary and the konlet container without errors.