### PR TITLE
Add branch name to tag in automatic Konlet builds

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,5 +4,5 @@ steps:
 - name: 'gcr.io/google-containers/busybox'
   args: ['cp', 'bazel-bin/gce-containers-startup/gce-containers-startup', 'docker/gce-containers-startup']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/gce-containers/konlet:HEAD', 'docker']
-images: ['gcr.io/gce-containers/konlet:HEAD']
+  args: ['build', '-t', 'gcr.io/gce-containers/konlet:$BRANCH_NAME-HEAD', 'docker']
+images: ['gcr.io/gce-containers/konlet:$BRANCH_NAME-HEAD']


### PR DESCRIPTION
The branch name is given as env variable:
https://cloud.google.com/cloud-build/docs/configuring-builds/substitute-variable-values