### PR TITLE
Remove some Konlet systemd dependencies

### DIFF
--- a/scripts/konlet-startup
+++ b/scripts/konlet-startup
@@ -23,6 +23,10 @@ if [[ $? -ne 0 ]]; then
   exit 0
 fi
 
+# Make sure that Docker events collector is running for Konlet (only if the
+# metadata is present).
+systemctl start docker-events-collector.service
+
 ACTUAL_KONLET_VERSION=$(${GET_METADATA_VALUE} 'attributes/gce-container-runner-version-override')
 if [[ $? -ne 0 ]]; then
   ACTUAL_KONLET_VERSION="${KONLET_VERSION_TAG}"

--- a/scripts/konlet-startup.service
+++ b/scripts/konlet-startup.service
@@ -14,8 +14,8 @@
 
 [Unit]
 Description=Containers on GCE Setup
-Wants=network-online.target google-startup-scripts.service gcr-online.target docker.socket docker-events-collector.service
-After=network-online.target google-startup-scripts.service gcr-online.target docker.socket docker-events-collector.service stackdriver-logging.service
+Wants=network-online.target google-startup-scripts.service gcr-online.target docker.socket
+After=network-online.target google-startup-scripts.service gcr-online.target docker.socket
 
 [Service]
 ExecStart=/usr/share/gce-containers/konlet-startup


### PR DESCRIPTION
Konlet service should not want the docker-events-collector.service,
because it should only be run if the relevant metadata is present.
Konlet also does not need the "after stackdriver-logging.service"
declaration, because it is ineffective due to how this service is
started, and it is not required (all logs will be picked up even if
stackdriver-logging service starts later in the process).