### PR TITLE
Remove all konlet containers on startup

### DIFF
--- a/gce-containers-startup/gce-containers-startup_test.go
+++ b/gce-containers-startup/gce-containers-startup_test.go
@@ -349,7 +349,7 @@ func TestExecStartup_simple(t *testing.T) {
 	utils.AssertEqual(t, "gcr.io/gce-containers/apache:v1", mockDockerClient.PulledImage, "")
 	utils.AssertEqual(t, "gcr.io/gce-containers/apache:v1", mockDockerClient.CreateRequest.Image, "")
 	utils.AssertEqual(t, MOCK_CONTAINER_ID, mockDockerClient.StartedContainer, "")
-	utils.AssertEqual(t, "", mockDockerClient.RemovedContainer, "")
+	utils.AssertEqual(t, MOCK_EXISTING_CONTAINER_ID, mockDockerClient.RemovedContainer, "")
 	mockDockerClient.assertDefaultOptions(t)
 }
 
@@ -370,7 +370,7 @@ func TestExecStartup_runCommand(t *testing.T) {
 	utils.AssertEqual(t, dockerstrslice.StrSlice([]string{"ls"}), mockDockerClient.CreateRequest.Entrypoint, "")
 	utils.AssertEqual(t, dockerstrslice.StrSlice([]string{"-l", "/tmp"}), mockDockerClient.CreateRequest.Cmd, "")
 	utils.AssertEqual(t, MOCK_CONTAINER_ID, mockDockerClient.StartedContainer, "")
-	utils.AssertEqual(t, "", mockDockerClient.RemovedContainer, "")
+	utils.AssertEqual(t, MOCK_EXISTING_CONTAINER_ID, mockDockerClient.RemovedContainer, "")
 	mockDockerClient.assertDefaultOptions(t)
 }
 
@@ -391,7 +391,7 @@ func TestExecStartup_runArgs(t *testing.T) {
 	utils.AssertEqual(t, dockerstrslice.StrSlice([]string{"echo"}), mockDockerClient.CreateRequest.Entrypoint, "")
 	utils.AssertEqual(t, dockerstrslice.StrSlice([]string{"-n", "Hello \" world", "Welco'me"}), mockDockerClient.CreateRequest.Cmd, "")
 	utils.AssertEqual(t, MOCK_CONTAINER_ID, mockDockerClient.StartedContainer, "")
-	utils.AssertEqual(t, "", mockDockerClient.RemovedContainer, "")
+	utils.AssertEqual(t, MOCK_EXISTING_CONTAINER_ID, mockDockerClient.RemovedContainer, "")
 	mockDockerClient.assertDefaultOptions(t)
 }
 
@@ -412,7 +412,7 @@ func TestExecStartup_env(t *testing.T) {
 	utils.AssertEqual(t, dockerstrslice.StrSlice([]string{"env"}), mockDockerClient.CreateRequest.Entrypoint, "")
 	utils.AssertEqual(t, []string{"VAR1=VAL1", "VAR2=VAL2"}, mockDockerClient.CreateRequest.Env, "")
 	utils.AssertEqual(t, MOCK_CONTAINER_ID, mockDockerClient.StartedContainer, "")
-	utils.AssertEqual(t, "", mockDockerClient.RemovedContainer, "")
+	utils.AssertEqual(t, MOCK_EXISTING_CONTAINER_ID, mockDockerClient.RemovedContainer, "")
 	mockDockerClient.assertDefaultOptions(t)
 }
 
@@ -439,7 +439,7 @@ func TestExecStartup_volumeMounts(t *testing.T) {
 		"")
 	utils.AssertEmpty(t, mockDockerClient.HostConfig.Tmpfs, "")
 	utils.AssertEqual(t, MOCK_CONTAINER_ID, mockDockerClient.StartedContainer, "")
-	utils.AssertEqual(t, "", mockDockerClient.RemovedContainer, "")
+	utils.AssertEqual(t, MOCK_EXISTING_CONTAINER_ID, mockDockerClient.RemovedContainer, "")
 	mockDockerClient.assertDefaultOptions(t)
 }
 
@@ -463,7 +463,7 @@ func TestExecStartup_options(t *testing.T) {
 	utils.AssertEqual(t, mockDockerClient.HostConfig.Privileged, true, "")
 	utils.AssertEqual(t, mockDockerClient.CreateRequest.OpenStdin, true, "")
 	utils.AssertEqual(t, mockDockerClient.CreateRequest.Tty, true, "")
-	utils.AssertEqual(t, "", mockDockerClient.RemovedContainer, "")
+	utils.AssertEqual(t, MOCK_EXISTING_CONTAINER_ID, mockDockerClient.RemovedContainer, "")
 	mockDockerClient.assertDefaultSystemOptions(t)
 }
 
@@ -527,7 +527,7 @@ func TestExecStartup_restartPolicy(t *testing.T) {
 	utils.AssertEqual(t, "gcr.io/google-containers/busybox:latest", mockDockerClient.PulledImage, "")
 	utils.AssertEqual(t, "gcr.io/google-containers/busybox:latest", mockDockerClient.CreateRequest.Image, "")
 	utils.AssertEqual(t, MOCK_CONTAINER_ID, mockDockerClient.StartedContainer, "")
-	utils.AssertEqual(t, "", mockDockerClient.RemovedContainer, "")
+	utils.AssertEqual(t, MOCK_EXISTING_CONTAINER_ID, mockDockerClient.RemovedContainer, "")
 	mockDockerClient.assertDefaultSystemOptions(t)
 	utils.AssertEqual(t, mockDockerClient.HostConfig.Privileged, false, "")
 	utils.AssertEqual(t, mockDockerClient.HostConfig.RestartPolicy.Name, "on-failure", "")
@@ -585,7 +585,7 @@ func TestExecStartup_ignorePodFields(t *testing.T) {
 	utils.AssertEqual(t, "gcr.io/gce-containers/apache:v1", mockDockerClient.PulledImage, "")
 	utils.AssertEqual(t, "gcr.io/gce-containers/apache:v1", mockDockerClient.CreateRequest.Image, "")
 	utils.AssertEqual(t, MOCK_CONTAINER_ID, mockDockerClient.StartedContainer, "")
-	utils.AssertEqual(t, "", mockDockerClient.RemovedContainer, "")
+	utils.AssertEqual(t, MOCK_EXISTING_CONTAINER_ID, mockDockerClient.RemovedContainer, "")
 	mockDockerClient.assertDefaultOptions(t)
 }
 
@@ -613,7 +613,7 @@ func TestExecStartup_pdValidAndFormatted(t *testing.T) {
 	utils.AssertEqual(t, []string{GCE_PD_HOST_MOUNT_PATH + ":/tmp/pd1"}, mockDockerClient.HostConfig.Binds, "")
 	utils.AssertEmpty(t, mockDockerClient.HostConfig.Tmpfs, "")
 	utils.AssertEqual(t, MOCK_CONTAINER_ID, mockDockerClient.StartedContainer, "")
-	utils.AssertEqual(t, "", mockDockerClient.RemovedContainer, "")
+	utils.AssertEqual(t, MOCK_EXISTING_CONTAINER_ID, mockDockerClient.RemovedContainer, "")
 	mockDockerClient.assertDefaultOptions(t)
 
 	mockCommandRunner.AssertAllCalled()
@@ -644,7 +644,7 @@ func TestExecStartup_pdValidAndFormatted_mountReadOnly(t *testing.T) {
 	utils.AssertEqual(t, []string{GCE_PD_HOST_MOUNT_PATH + ":/tmp/pd1:ro"}, mockDockerClient.HostConfig.Binds, "")
 	utils.AssertEmpty(t, mockDockerClient.HostConfig.Tmpfs, "")
 	utils.AssertEqual(t, MOCK_CONTAINER_ID, mockDockerClient.StartedContainer, "")
-	utils.AssertEqual(t, "", mockDockerClient.RemovedContainer, "")
+	utils.AssertEqual(t, MOCK_EXISTING_CONTAINER_ID, mockDockerClient.RemovedContainer, "")
 	mockDockerClient.assertDefaultOptions(t)
 
 	mockCommandRunner.AssertAllCalled()
@@ -673,7 +673,7 @@ func TestExecStartup_pdValidAndFormatted_attachedReadOnly_mountReadOnly(t *testi
 	utils.AssertEqual(t, []string{GCE_PD_HOST_MOUNT_PATH + ":/tmp/pd1:ro"}, mockDockerClient.HostConfig.Binds, "")
 	utils.AssertEmpty(t, mockDockerClient.HostConfig.Tmpfs, "")
 	utils.AssertEqual(t, MOCK_CONTAINER_ID, mockDockerClient.StartedContainer, "")
-	utils.AssertEqual(t, "", mockDockerClient.RemovedContainer, "")
+	utils.AssertEqual(t, MOCK_EXISTING_CONTAINER_ID, mockDockerClient.RemovedContainer, "")
 	mockDockerClient.assertDefaultOptions(t)
 
 	mockCommandRunner.AssertAllCalled()
@@ -738,7 +738,7 @@ func TestExecStartup_pdWithPartitionValidAndFormatted(t *testing.T) {
 	utils.AssertEqual(t, []string{GCE_PD_HOST_MOUNT_PATH + ":/tmp/pd1"}, mockDockerClient.HostConfig.Binds, "")
 	utils.AssertEmpty(t, mockDockerClient.HostConfig.Tmpfs, "")
 	utils.AssertEqual(t, MOCK_CONTAINER_ID, mockDockerClient.StartedContainer, "")
-	utils.AssertEqual(t, "", mockDockerClient.RemovedContainer, "")
+	utils.AssertEqual(t, MOCK_EXISTING_CONTAINER_ID, mockDockerClient.RemovedContainer, "")
 	mockDockerClient.assertDefaultOptions(t)
 
 	mockCommandRunner.AssertAllCalled()
@@ -796,7 +796,7 @@ func TestExecStartup_pdValidAndNotFormatted(t *testing.T) {
 	utils.AssertEqual(t, []string{GCE_PD_HOST_MOUNT_PATH + ":/tmp/pd1"}, mockDockerClient.HostConfig.Binds, "")
 	utils.AssertEmpty(t, mockDockerClient.HostConfig.Tmpfs, "")
 	utils.AssertEqual(t, MOCK_CONTAINER_ID, mockDockerClient.StartedContainer, "")
-	utils.AssertEqual(t, "", mockDockerClient.RemovedContainer, "")
+	utils.AssertEqual(t, MOCK_EXISTING_CONTAINER_ID, mockDockerClient.RemovedContainer, "")
 	mockDockerClient.assertDefaultOptions(t)
 
 	mockCommandRunner.AssertAllCalled()

--- a/gce-containers-startup/runtime/BUILD
+++ b/gce-containers-startup/runtime/BUILD
@@ -35,3 +35,16 @@ go_library(
         "//gce-containers-startup/volumes",
     ],
 )
+
+go_test(
+    name = "runtime_test",
+    srcs = [
+        "runtime_test.go",
+    ],
+    embed = [":runtime"],
+    importpath = "github.com/GoogleCloudPlatform/konlet/gce-containers-startup/runtime",
+    deps = [
+        "//gce-containers-startup/utils:go_default_library",
+        "//gce-containers-startup/vendor:github.com/docker/engine-api/types",
+    ],
+)

--- a/gce-containers-startup/runtime/runtime.go
+++ b/gce-containers-startup/runtime/runtime.go
@@ -178,11 +178,11 @@ func deleteOldContainers(dockerClient DockerApiClient, rawName string) error {
 	}
 	idsNames := containersStartedByKonlet(containers, rawName)
 	if len(idsNames) == 0 {
-		log.Print("No containers to delete.\n")
+		log.Print("No containers created by previous runs of Konlet found.\n")
 		return nil
 	}
 	for id, name := range idsNames {
-		log.Printf("Removing previous container '%s' (ID: %s)\n", name, id)
+		log.Printf("Removing a container created by a previous run of Konlet: '%s' (ID: %s)\n", name, id)
 		rmOpts := dockertypes.ContainerRemoveOptions{
 			Force: true,
 		}

--- a/gce-containers-startup/runtime/runtime.go
+++ b/gce-containers-startup/runtime/runtime.go
@@ -165,40 +165,62 @@ func pullImage(dockerClient DockerApiClient, auth string, spec api.Container) er
 	return nil
 }
 
-func findIdForName(containers []dockertypes.Container, containerName string) (string, bool) {
-	var searchName = "/" + containerName
-	for _, container := range containers {
-		for _, name := range container.Names {
-			if name == searchName {
-				return container.ID, true
-			}
-		}
-	}
-	return "", false
-}
-
-func deleteOldContainer(dockerClient DockerApiClient, containerName string) error {
+// deleteOldContainers deletes all containers started by konlet.
+// rawName is a container name without any generate prefixes or suffixes.
+func deleteOldContainers(dockerClient DockerApiClient, rawName string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	listOpts := dockertypes.ContainerListOptions{All: true}
-	resp, err := dockerClient.ContainerList(ctx, listOpts)
-
+	containers, err := dockerClient.ContainerList(ctx, listOpts)
 	if err != nil {
 		return err
 	}
-
-	containerID, exists := findIdForName(resp, containerName)
-	if !exists {
-		log.Printf("Container with name '%s' has not yet been run.\n", containerName)
+	idsNames := containersStartedByKonlet(containers, rawName)
+	if len(idsNames) == 0 {
+		log.Print("No containers to delete.\n")
 		return nil
 	}
-
-	log.Printf("Removing previous container '%s' (ID: %s)\n", containerName, containerID)
-	rmOpts := dockertypes.ContainerRemoveOptions{
-		Force: true,
+	for id, name := range idsNames {
+		log.Printf("Removing previous container '%s' (ID: %s)\n", name, id)
+		rmOpts := dockertypes.ContainerRemoveOptions{
+			Force: true,
+		}
+		if err := dockerClient.ContainerRemove(ctx, id, rmOpts); err != nil {
+			return err
+		}
 	}
-	return dockerClient.ContainerRemove(ctx, containerID, rmOpts)
+	return nil
+}
+
+// containersStartedByKonlet filters a given list of containers to return a map
+// from container id to container name for containers started by konlet.
+// These are all containers whose names match one of two cases:
+// 1. the name starts with '/klt-',
+// 2. the name is '/<rawName>', where rawName is a legacy container name passed as an argument.
+// NOTE: The reason for the leading slash is Docker's convention of adding these
+// to names specified by the user.
+// NOTE: The reason for two cases above is that historically konlet started
+// containers without prefixes or suffixes and it would fail to delete an old
+// container after system update to a newer version if it only looked for the prefix.
+// See https://github.com/GoogleCloudPlatform/konlet/issues/50
+func containersStartedByKonlet(containers []dockertypes.Container, rawName string) map[string]string {
+	var (
+		// Matches containers started by konlet.
+		namePattern1 = "/klt-"
+		// The legacy pattern, see the comment on top of the function.
+		namePattern2 = "/" + rawName
+	)
+	idsNames := make(map[string]string)
+	for _, container := range containers {
+		for _, name := range container.Names {
+			if strings.HasPrefix(name, namePattern1) || name == namePattern2 {
+				idsNames[container.ID] = name
+				break
+			}
+		}
+	}
+	return idsNames
 }
 
 func createContainer(runner ContainerRunner, auth string, spec api.ContainerSpecStruct) (string, error) {
@@ -214,7 +236,7 @@ func createContainer(runner ContainerRunner, auth string, spec api.ContainerSpec
 		return "", err
 	}
 
-	if err := deleteOldContainer(runner.Client, generatedContainerName); err != nil {
+	if err := deleteOldContainers(runner.Client, container.Name); err != nil {
 		return "", err
 	}
 

--- a/gce-containers-startup/runtime/runtime_test.go
+++ b/gce-containers-startup/runtime/runtime_test.go
@@ -38,7 +38,7 @@ func Test_containersStartedByKonlet_DoesNotMatchOtherContainers(t *testing.T) {
 		generateContainerStruct(t, "1", "/kltsadashdk"),
 		generateContainerStruct(t, "2", "/user-container"),
 	}
-	returned := containersStartedByKonlet(containers, "container2")
+	returned := containersStartedByKonlet(containers, "container")
 	expected := map[string]string{}
 	utils.AssertEqual(t, returned, expected, "")
 }

--- a/gce-containers-startup/runtime/runtime_test.go
+++ b/gce-containers-startup/runtime/runtime_test.go
@@ -1,0 +1,54 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"github.com/GoogleCloudPlatform/konlet/gce-containers-startup/utils"
+	dockertypes "github.com/docker/engine-api/types"
+	"testing"
+)
+
+func Test_containersStartedByKonlet_MatchesKonletContainers(t *testing.T) {
+	containers := []dockertypes.Container{
+		generateContainerStruct(t, "1", "/klt-container1-abcd"),
+		generateContainerStruct(t, "2", "/container2"),
+	}
+	returned := containersStartedByKonlet(containers, "container2")
+	expected := map[string]string{
+		"1": "/klt-container1-abcd",
+		"2": "/container2",
+	}
+	utils.AssertEqual(t, returned, expected, "")
+}
+
+func Test_containersStartedByKonlet_DoesNotMatchOtherContainers(t *testing.T) {
+	containers := []dockertypes.Container{
+		generateContainerStruct(t, "1", "/kltsadashdk"),
+		generateContainerStruct(t, "2", "/user-container"),
+	}
+	returned := containersStartedByKonlet(containers, "container2")
+	expected := map[string]string{}
+	utils.AssertEqual(t, returned, expected, "")
+}
+
+// generateContainerStruct is a utility function that fills some of the fields of
+// dockertypes.Container for purposes of testing the functions in this package.
+func generateContainerStruct(t *testing.T, id, name string) dockertypes.Container {
+	t.Helper()
+	return dockertypes.Container{
+		ID:    id,
+		Names: []string{name},
+	}
+}


### PR DESCRIPTION
On startup remove all containers that either start with a prefix 'klt-'
or have exactly the same name as in the container spec.