### PR TITLE
Add support for passing tokens to Artifact Registry

### DIFF
--- a/gce-containers-startup/utils/registry.go
+++ b/gce-containers-startup/utils/registry.go
@@ -16,9 +16,10 @@ package utils
 
 import "strings"
 
-// Returns true iff the provided image string points to repository
-// that uses a GCP token. Currently, that is:
+// UseGcpTokenForImage returns true iff the provided image string points to
+// a repository that uses a GCP token. Currently, that is:
 //  - gcr.io
+//  - pkg.dev
 func UseGcpTokenForImage(image string) bool {
 	parts := strings.SplitN(image, "/", 2)
 
@@ -28,5 +29,5 @@ func UseGcpTokenForImage(image string) bool {
 
 	hostname := strings.ToLower(parts[0])
 
-	return hostname == "gcr.io" || strings.HasSuffix(hostname, ".gcr.io")
+	return hostname == "gcr.io" || strings.HasSuffix(hostname, ".gcr.io") || strings.HasSuffix(hostname, ".pkg.dev")
 }

--- a/gce-containers-startup/utils/utils_test.go
+++ b/gce-containers-startup/utils/utils_test.go
@@ -43,6 +43,13 @@ func TestDefaultRegistry_gcr(t *testing.T) {
 	assertRegistryGetsToken(t, "oh.my.this-is-not-gcr.io/other-containers/busybox", false)
 }
 
+func TestDefaultRegistry_ar(t *testing.T) {
+	assertRegistryGetsToken(t, "us-docker.pkg.dev/project/google-containers/nginx", true)
+	assertRegistryGetsToken(t, "us-west1-docker.pkg.dev/project/google-containers/nginx:1.2", true)
+	assertRegistryGetsToken(t, "australia-southeast1-docker.pkg.dev/project/other-containers/busybox", true)
+	assertRegistryGetsToken(t, "not-docker-pkg.dev/project/other-containers/busybox", false)
+}
+
 func assertRegistryGetsToken(t *testing.T, image string, expectedToken bool) {
 	AssertEqual(t,
 		UseGcpTokenForImage(image),


### PR DESCRIPTION
Artifact Registry is a Google Cloud service for managing docker artifacts, it is the successor to GCR. This PR adds support for sending access tokens to Artifact Registry domains, so that konlet can pull images from AR repositories.