### PR TITLE
Rotate 3 logs up to 500MB each.

### DIFF
--- a/gce-containers-startup/runtime/runtime.go
+++ b/gce-containers-startup/runtime/runtime.go
@@ -309,6 +309,10 @@ func createContainer(runner ContainerRunner, auth string, spec api.ContainerSpec
 			Privileged:  container.SecurityContext.Privileged,
 			LogConfig: dockercontainer.LogConfig{
 				Type: "json-file",
+				Config: map[string]string{
+					"max-size": "500m",
+					"max-file": "3",
+				},
 			},
 			RestartPolicy: dockercontainer.RestartPolicy{
 				Name: restartPolicyName,


### PR DESCRIPTION
This has been manually tested with a python script printing 2kb lorem ipsum into stderr, using a smaller file size limit (1MB).