### PR TITLE
Remove unused loads

### DIFF
--- a/gce-containers-startup/BUILD
+++ b/gce-containers-startup/BUILD
@@ -22,8 +22,6 @@ load(
     "go_library",
     "go_test",
 )
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_deb", "pkg_tar")
 
 go_binary(
     name = "gce-containers-startup",


### PR DESCRIPTION
`docker_build`, `pkg_deb`, and `pkg_tar` don't appear to be used.

Close https://github.com/GoogleCloudPlatform/konlet/issues/70