### PR TITLE
Fix error handling in get_metadata_value script.

### DIFF
--- a/scripts/get_metadata_value
+++ b/scripts/get_metadata_value
@@ -45,7 +45,7 @@ function get_metadata_value() {
   print_metadata_value_if_exists ${MDS_PREFIX}/instance/${varname}
   return_code=$?
   # If the instance doesn't have the value, try the project.
-  if [[ ${return_code} != 0 ]]; then
+  if [[ ${return_code} != 0 && ${return_code} != 6 && ${return_code} != 7 ]]; then
     print_metadata_value_if_exists ${MDS_PREFIX}/project/${varname}
     return_code=$?
   fi


### PR DESCRIPTION
The error case is the following:

1. Have some value in instance metadata but not project metadata.

2. Hit some connection issue getting instance metadata value in print_metadata_value_if_exists ${MDS_PREFIX}/instance/${varname}

3. successfully fetch project metadata, which returns that the value doesn't exist

4. get_metadata_value_with_retries doesn't retry because the return code doesn't indicate a connection error