### PR TITLE
Updating debian 12 image as version tags are supported now, and a fix…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The repository does not use version tags, so the only way to pin a version is to use the full hash.
-# The hash below is 'latest' as of 2024-11-12
-FROM  gcr.io/cloud-marketplace/google/debian12@sha256:ce96510e0ac954fbc65db75901c71766f0137fcd16a8915f717e1fb6fbe0f2a3
-
+FROM  gcr.io/cloud-marketplace/google/debian12:latest
 RUN apt-get update && apt-get install -y iptables mount e2fsprogs util-linux
 COPY gce-containers-startup /bin/gce-containers-startup
 


### PR DESCRIPTION
…ed version is prone to CVEs detected